### PR TITLE
Added option to sort by fastest server connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,14 @@ sudo openvpn --config riseup-ovpn.conf
 curl ipinfo.io
 ```
 
-| Options           | Description                                                                                                    |
-| ----------------- | -------------------------------------------------------------------------------------------------------------- |
-| `-v`              | Verbose mode.                                                                                                  |
-| `-vvv`            | Very verbose mode (enables `set -x` for full debugging output).                                                |
-| `--no-ipv6`       | Explicitly disables IPv6 in the generated OpenVPN configuration. Required if IPv6 is disabled on your host.    |
-| `--no-dns-leak`   | Add up/down scripts to avoid using your ISP's DNS servers (DNS queries go through the tunnel anyway).          |
+| Options               | Description                                                                                                    |
+| --------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `-v`                  | Verbose mode.                                                                                                  |
+| `-vvv`                | Very verbose mode (enables `set -x` for full debugging output).                                                |
+| `--no-ipv6`           | Explicitly disables IPv6 in the generated OpenVPN configuration. Required if IPv6 is disabled on your host.    |
+| `--no-dns-leak`       | Add up/down scripts to avoid using your ISP's DNS servers (DNS queries go through the tunnel anyway).          |
+| `--sort-by-fastest`   | Sorts servers in the generated OpenVPN configuration by fastest connection speed.                              |
+
 
 ## What is RiseupVPN ?
 


### PR DESCRIPTION
**Feature**: 
When building the OpenVPN configuration file, ping all servers and sort them by fastest connection speed.
- The option to perform this functionality is `--sort-by-fastest`.
- The resulting configuration file also includes the average ping of each server in a comment if `--sort-by-fastest` was specified.

**Example of configuration file**:
```
remote 89.187.173.174 53 # vpn23-mia.riseup.net (Miami) 125.943 ms
remote 89.187.173.174 80 # vpn23-mia.riseup.net (Miami) 125.943 ms
remote 89.187.173.174 1194 # vpn23-mia.riseup.net (Miami) 125.943 ms
remote 199.58.83.9 53 # vpn18-mtl.riseup.net (Montreal) 126.546 ms
remote 199.58.83.9 80 # vpn18-mtl.riseup.net (Montreal) 126.546 ms
remote 199.58.83.9 1194 # vpn18-mtl.riseup.net (Montreal) 126.546 ms
remote 89.187.173.169 53 # vpn22-mia.riseup.net (Miami) 128.170 ms
remote 89.187.173.169 80 # vpn22-mia.riseup.net (Miami) 128.170 ms
remote 89.187.173.169 1194 # vpn22-mia.riseup.net (Miami) 128.170 ms
remote 51.159.196.108 53 # vpn14-par.riseup.net (Paris) 128.838 ms
remote 51.159.196.108 80 # vpn14-par.riseup.net (Paris) 128.838 ms
remote 51.159.196.108 1194 # vpn14-par.riseup.net (Paris) 128.838 ms
remote 185.220.103.11 53 # vpn12-nyc.riseup.net (New_York_City) 129.010 ms
remote 185.220.103.11 80 # vpn12-nyc.riseup.net (New_York_City) 129.010 ms
remote 185.220.103.11 1194 # vpn12-nyc.riseup.net (New_York_City) 129.010 ms
remote 51.15.9.205 53 # vpn04-ams.riseup.net (Amsterdam) 130.708 ms
remote 51.15.9.205 80 # vpn04-ams.riseup.net (Amsterdam) 130.708 ms
remote 51.15.9.205 1194 # vpn04-ams.riseup.net (Amsterdam) 130.708 ms
...
```