### PR TITLE
Added Location Filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ curl ipinfo.io
 | `-vvv`            | Very verbose mode (enables `set -x` for full debugging output).                                                |
 | `--no-ipv6`       | Explicitly disables IPv6 in the generated OpenVPN configuration. Required if IPv6 is disabled on your host.    |
 | `--no-dns-leak`   | Add up/down scripts to avoid using your ISP's DNS servers (DNS queries go through the tunnel anyway).          |
+| `--list-locations`   | Shows avaliable locations.          |
 
 ## What is RiseupVPN ?
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@ sudo openvpn --config riseup-ovpn.conf
 curl ipinfo.io
 ```
 
-| Options           | Description                                                                                                    |
-| ----------------- | -------------------------------------------------------------------------------------------------------------- |
-| `-v`              | Verbose mode.                                                                                                  |
-| `-vvv`            | Very verbose mode (enables `set -x` for full debugging output).                                                |
-| `--no-ipv6`       | Explicitly disables IPv6 in the generated OpenVPN configuration. Required if IPv6 is disabled on your host.    |
-| `--no-dns-leak`   | Add up/down scripts to avoid using your ISP's DNS servers (DNS queries go through the tunnel anyway).          |
-| `--list-locations`   | Shows avaliable locations.          |
+| Options            | Description                                                                                                                      |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `-v`               | Verbose mode.                                                                                                                    |
+| `-vvv`             | Very verbose mode (enables `set -x` for full debugging output).                                                                  |
+| `--no-ipv6`        | Explicitly disables IPv6 in the generated OpenVPN configuration. Required if IPv6 is disabled on your host.                      |
+| `--no-dns-leak`    | Add up/down scripts to avoid using your ISP's DNS servers (DNS queries go through the tunnel anyway).                            |
+| `--list-locations` | Shows avaliable locations.                                                                                                       |
+| `--locations`      | Comma-separated list of locations to include in the generated config. Example: `./generate.sh --locations "New York City,Miami"` |
 
 ## What is RiseupVPN ?
 
@@ -29,26 +30,26 @@ A free (funded through donations) and privacy oriented VPN.
 
 ### <https://riseup.net/en/vpn>
 
-> * Riseup offers Personal VPN service for censorship circumvention, location anonymization and traffic encryption.
-> * Unlike most other VPN providers, Riseup does not log your IP address.
-> * The RiseupVPN service is entirely funded through donations from users.
+> - Riseup offers Personal VPN service for censorship circumvention, location anonymization and traffic encryption.
+> - Unlike most other VPN providers, Riseup does not log your IP address.
+> - The RiseupVPN service is entirely funded through donations from users.
 
 ### <https://riseup.net/en/privacy-policy>
 
-> * No IP addresses of any user for any service are retained.
+> - No IP addresses of any user for any service are retained.
 
 ### <https://riseup.net/en/about-us/policy/government-faq>
 
-> * We are not working with any government agency. We have never simply handed over information when requested, and for years have had a no logging policy. We have fought and won every time anyone has tried to get us to give up information. We have never turned over any user data to any third party, fourth party, fifth party or any party.
-> * This (take Riseup's servers) usually happens when they (law enforcement) want logs, we tell them that we don’t have any and then they come and take the machine because they don’t believe us and want to see for themselves. However, all of our servers use full disk encryption, which means they cannot see or do anything with the data on the disks without the keys. Nevertheless, we do not keep IP identifying logs, and store as little data as possible on our users.
+> - We are not working with any government agency. We have never simply handed over information when requested, and for years have had a no logging policy. We have fought and won every time anyone has tried to get us to give up information. We have never turned over any user data to any third party, fourth party, fifth party or any party.
+> - This (take Riseup's servers) usually happens when they (law enforcement) want logs, we tell them that we don’t have any and then they come and take the machine because they don’t believe us and want to see for themselves. However, all of our servers use full disk encryption, which means they cannot see or do anything with the data on the disks without the keys. Nevertheless, we do not keep IP identifying logs, and store as little data as possible on our users.
 
 ## References
 
-* <https://riseup.net/en/vpn>
-* <https://riseup.net/en/privacy-policy>
-* <https://riseup.net/en/about-us/policy/government-faq>
-* <https://gist.github.com/crass/7952d79b596a89e067292ea68e3f0754>
-* <https://openvpn.net/community-resources/reference-manual-for-openvpn-2-6/>
+- <https://riseup.net/en/vpn>
+- <https://riseup.net/en/privacy-policy>
+- <https://riseup.net/en/about-us/policy/government-faq>
+- <https://gist.github.com/crass/7952d79b596a89e067292ea68e3f0754>
+- <https://openvpn.net/community-resources/reference-manual-for-openvpn-2-6/>
 
 ## Donate
 

--- a/generate.sh
+++ b/generate.sh
@@ -80,6 +80,26 @@ fi
 if [ -n "${CURL_NO_SILENT+x}" ]; then echo "curl riseup servers list from https://api.black.riseup.net/3/config/eip-service.json"; fi
 # shellcheck disable=SC2086
 gateways=$(curl ${CURL_VERBOSE:+-v} ${CURL_NO_SILENT--sS} --fail --connect-timeout 10 --retry 3 -H "Accept: application/json" https://api.black.riseup.net/3/config/eip-service.json | jq '.gateways')
+location_arg=""
+prev_arg=""
+for arg in "$@"; do
+    if [[ "$prev_arg" == "--location" ]]; then
+        location_arg="$arg"
+        break
+    fi
+    prev_arg="$arg"
+done
+
+if [[ -n "$location_arg" ]]; then
+    echo -e "\e[33;3mFiltering servers by locations: $location_arg\e[0m"
+    gateways=$(echo "$gateways" | jq --arg locations "$location_arg" '
+        ($locations
+         | split(",")
+         | map(gsub("^\\s+|\\s+$"; ""))
+         | map(select(length > 0))) as $wanted
+        | map(select(.location as $loc | any($wanted[]; . == $loc)))
+    ')
+fi
 
 for gateway_b64 in $(echo "$gateways" | jq -r '.[] | @base64'); do
     gateway=$(echo "$gateway_b64" | base64 -d)

--- a/generate.sh
+++ b/generate.sh
@@ -70,6 +70,12 @@ up "/usr/bin/env bash -c '\''/etc/openvpn/update-resolv-conf $* || /etc/openvpn/
 down "/usr/bin/env bash -c '\''/etc/openvpn/update-resolv-conf $* || /etc/openvpn/down.sh $*'\''"' >>$OVPN_CONF
 fi
 
+if [[ "$ARGS" = *" --list-locations "* ]]; then
+    echo -e "\e[33;3mAvailable locations:\e[0m"
+    curl ${CURL_VERBOSE:+-v} ${CURL_NO_SILENT--sS} --fail --connect-timeout 10 --retry 3 -H "Accept: application/json" https://api.black.riseup.net/3/config/eip-service.json | jq -r '.gateways[] | .location' | sort -u
+    exit 0
+fi
+
 # Get the VPN IP list, and add them to openvpn conf
 if [ -n "${CURL_NO_SILENT+x}" ]; then echo "curl riseup servers list from https://api.black.riseup.net/3/config/eip-service.json"; fi
 # shellcheck disable=SC2086


### PR DESCRIPTION
This PR adds new CLI arguments to enable server location selection when generating the OpenVPN config.

What changed

Added --list-locations to print all available Riseup gateway locations.
Added --locations "location1, location2" to filter gateways by one or more locations.
Keeps existing behavior unchanged when --locations is not provided.